### PR TITLE
Major bug, combine_flat is scaling individual frames incorrectly. Implemented sigma clipping combine flats

### DIFF
--- a/spectral_reduction/keck_basic_2d.py
+++ b/spectral_reduction/keck_basic_2d.py
@@ -8,6 +8,17 @@ from astropy.io import ascii
 from scipy import signal, ndimage
 #DO NOT IMPORT MATPLOTLIB, CAUSES IRAF TO CRASH?
 
+###Python 3 compatibility check
+try:
+    basestring
+except NameError:
+    basestring = str
+
+try:
+    xrange
+except:
+    xrange = range
+
 def load_sections(string, fmt_iraf=True):
     """
     Modified from pypit.core.parse.load_sections -- Jon Brown
@@ -847,7 +858,7 @@ def main(rawFiles,*args,**kwargs):
 
     # loop over raw files, if the destination exists, do nothing
     # otherwise, do the bias/reorient/trim/output
-    for i in xrange(len(rawFiles)):
+    for i in range(len(rawFiles)):
         
         rawFile = rawFiles[i]
         oScanFile = 'pre_reduced/to{}'.format(rawFile)
@@ -1069,7 +1080,7 @@ def main_new_red_amp(rawFiles,*args,**kwargs):
 
     # loop over raw files, if the destination exists, do nothing
     # otherwise, do the bias/reorient/trim/output
-    for i in xrange(len(rawFiles)):
+    for i in range(len(rawFiles)):
         
         rawFile = rawFiles[i]
         oScanFile = 'pre_reduced/to{}'.format(rawFile)

--- a/spectral_reduction/keck_basic_2d.py
+++ b/spectral_reduction/keck_basic_2d.py
@@ -378,7 +378,7 @@ def read_lris_new_red_amp(raw_file, det=None, TRIM=False):
     fil = glob.glob(raw_file)
 
     # Read
-    outStr = "Reading LRIS file: {:s}".format(fil)
+    outStr = "Reading LRIS file: {:s}".format(fil[0])
     print(outStr)
     hdu = fits.open(fil[0])
     data = hdu[0].data

--- a/spectral_reduction/pre_reduction_dev.py
+++ b/spectral_reduction/pre_reduction_dev.py
@@ -17,7 +17,7 @@ import host_galaxies as host_gals
 import numpy as np
 
 matplotlib.use('TkAgg')
-from flat_utils import combine_flats,inspect_flat
+from flat_utils import combine_flats,combine_flats_sig_clip, inspect_flat
 
 
 def show_ds9_listfile(listFile,instanceName='default'):
@@ -654,8 +654,10 @@ def pre_reduction_dev(*args,**kwargs):
                 os.remove(Flat_blue_amp2)
 
             # first, combine all the flat files into a master flat
-            res = combine_flats(flat_list_amp1,OUTFILE=Flat_blue_amp1,MEDIAN_COMBINE=False)
-            res = combine_flats(flat_list_amp2,OUTFILE=Flat_blue_amp2,MEDIAN_COMBINE=False)
+            # res = combine_flats(flat_list_amp1,OUTFILE=Flat_blue_amp1,MEDIAN_COMBINE=False)
+            # res = combine_flats(flat_list_amp2,OUTFILE=Flat_blue_amp2,MEDIAN_COMBINE=False)
+            res = combine_flats_sig_clip(flat_list_amp1,OUTFILE=Flat_blue_amp1,sigma = 3)
+            res = combine_flats_sig_clip(flat_list_amp2,OUTFILE=Flat_blue_amp2,sigma = 3)
             
             # run iraf response
             iraf.specred.response(Flat_blue_amp1, 
@@ -723,10 +725,13 @@ def pre_reduction_dev(*args,**kwargs):
 
             # first, combine all the flat files into a master flat
             if not RED_AMP_BAD:
-                res = combine_flats(flat_list_amp1,OUTFILE=Flat_red_amp1,MEDIAN_COMBINE=True)
-                res = combine_flats(flat_list_amp2,OUTFILE=Flat_red_amp2,MEDIAN_COMBINE=True)
+                # res = combine_flats(flat_list_amp1,OUTFILE=Flat_red_amp1,MEDIAN_COMBINE=True)
+                # res = combine_flats(flat_list_amp2,OUTFILE=Flat_red_amp2,MEDIAN_COMBINE=True)
+                res = combine_flats_sig_clip(flat_list_amp1,OUTFILE=Flat_red_amp1,sigma = 3)
+                res = combine_flats_sig_clip(flat_list_amp2,OUTFILE=Flat_red_amp2,sigma = 3)
             else:
-                res = combine_flats(flat_list_amp1,OUTFILE=Flat_red_amp1,MEDIAN_COMBINE=True)
+                # res = combine_flats(flat_list_amp1,OUTFILE=Flat_red_amp1,MEDIAN_COMBINE=True)
+                res = combine_flats_sig_clip(flat_list_amp1,OUTFILE=Flat_red_amp1,sigma = 3)
 
             #What is the output here? Check for overwrite
             print (Flat_red_amp1)
@@ -822,11 +827,14 @@ def pre_reduction_dev(*args,**kwargs):
                 os.remove(Flat_blue)
 
             # first, combine all the flat files into a master flat
-            res = combine_flats(flat_list,OUTFILE=Flat_blue,MEDIAN_COMBINE=True)
+            # res = combine_flats(flat_list,OUTFILE=Flat_blue,MEDIAN_COMBINE=True)
+            res = combine_flats_sig_clip(flat_list,OUTFILE=Flat_blue,sigma = 3)
+
             # combine all the flat files for norm region
             if os.path.isfile('pre_reduced/dummy_blue.fits'):
                 os.remove('pre_reduced/dummy_blue.fits')
-            res = combine_flats(norm_list,OUTFILE='pre_reduced/dummy_blue.fits',MEDIAN_COMBINE=True)
+            # res = combine_flats(norm_list,OUTFILE='pre_reduced/dummy_blue.fits',MEDIAN_COMBINE=True)
+            res = combine_flats_sig_clip(norm_list,OUTFILE='pre_reduced/dummy_blue.fits',sigma = 3)
         
             #can't get this to work:
             # _flatsec0 = inst.get('flatsec')
@@ -873,11 +881,14 @@ def pre_reduction_dev(*args,**kwargs):
                 os.remove(Flat_red)
 
             # first, combine all the flat files into a master flat
-            res = combine_flats(flat_list,OUTFILE=Flat_red,MEDIAN_COMBINE=True)
+            # res = combine_flats(flat_list,OUTFILE=Flat_red,MEDIAN_COMBINE=True)
+            res = combine_flats_sig_clip(flat_list,OUTFILE=Flat_red,sigma = 3)
+
             # combine all the flat files for norm region
             if os.path.isfile('pre_reduced/dummy_red.fits'):
                 os.remove('pre_reduced/dummy_red.fits')
-            res = combine_flats(norm_list,OUTFILE='pre_reduced/dummy_red.fits',MEDIAN_COMBINE=True)
+            # res = combine_flats(norm_list,OUTFILE='pre_reduced/dummy_red.fits',MEDIAN_COMBINE=True)
+            res = combine_flats_sig_clip(norm_list,OUTFILE='pre_reduced/dummy_red.fits',sigma = 3)
 
             
             # run iraf response
@@ -1118,8 +1129,9 @@ def pre_reduction_orig():
                 os.remove(Flat_blue)
 
             # first, combine all the flat files into a master flat
-            res = combine_flats(flat_list,OUTFILE=Flat_blue,MEDIAN_COMBINE=True)
-            
+            # res = combine_flats(flat_list,OUTFILE=Flat_blue,MEDIAN_COMBINE=True)
+            res = combine_flats_sig_clip(flat_list,OUTFILE=Flat_blue,sigma = 3)
+
             # run iraf response
             iraf.specred.response(Flat_blue, 
                                    normaliz=Flat_blue, 
@@ -1147,7 +1159,8 @@ def pre_reduction_orig():
                 os.remove(Flat_red)
 
             # first, combine all the flat files into a master flat
-            res = combine_flats(flat_list,OUTFILE=Flat_red,MEDIAN_COMBINE=True)
+            # res = combine_flats(flat_list,OUTFILE=Flat_red,MEDIAN_COMBINE=True)
+            res = combine_flats_sig_clip(flat_list,OUTFILE=Flat_red,sigma = 3)
 
             #What is the output here? Check for overwrite
             iraf.specred.response(Flat_red, 

--- a/spectral_reduction/pyzapspec.py
+++ b/spectral_reduction/pyzapspec.py
@@ -327,7 +327,10 @@ def pyzapspec(infile,
 
         fixed = False
         if np.shape(zapimage)[0] < np.shape(zapimage)[1]:
-            trace_y = int(raw_input('Enter approximate row of trace [360]: ') or 360)
+            try:
+                trace_y = int(raw_input('Enter approximate row of trace [360]: ') or 360)
+            except:
+                trace_y = int(input('Enter approximate row of trace [360]: ') or 360)
             buff_y = 30
             while not fixed:
                 rect = patches.Rectangle((0, trace_y - int(buff_y)), len(zapimage[0]), 2*buff_y, linewidth=1, edgecolor='r', facecolor='none')
@@ -337,20 +340,29 @@ def pyzapspec(infile,
                 plt.gca().invert_yaxis()
                 plt.draw()
                 plt.show(block=False)
-                col_str = raw_input('Enter a new column mask region of trace [900 1100] (n for none): ') or '900 1100'
+                try:
+                    col_str = raw_input('Enter a new column mask region of trace [900 1100] (n for none): ') or '900 1100'
+                except:
+                    col_str = input('Enter a new column mask region of trace [900 1100] (n for none): ') or '900 1100'
                 if col_str == 'n':
                     fixed = True
                 else:
                     col_left = int(col_str.split()[0])
                     col_right = int(col_str.split()[1])
                     zapimage[trace_y-buff_y:trace_y+buff_y, col_left:col_right] = 0
-                    new_reg = raw_input('Enter another region [y]/n: ') or 'y'
+                    try:
+                        new_reg = raw_input('Enter another region [y]/n: ') or 'y'
+                    except:
+                        new_reg = input('Enter another region [y]/n: ') or 'y'
                     if new_reg != 'y':
                         fixed = True
                 plt.close()
             zapimage_ravel = zapimage.ravel()
         else:
-            trace_x = int(raw_input('Enter approximate column of trace [808]: ') or 808)
+            try:
+                trace_x = int(raw_input('Enter approximate column of trace [808]: ') or 808)
+            except:
+                trace_x = int(input('Enter approximate column of trace [808]: ') or 808)
             buff_x = 30
             while not fixed:
                 rect = patches.Rectangle((trace_x - int(buff_x), 0), 2*buff_x, np.shape(zapimage)[0], linewidth=1, edgecolor='r', facecolor='none')
@@ -360,14 +372,20 @@ def pyzapspec(infile,
                 plt.gca().invert_yaxis()
                 plt.draw()
                 plt.show(block=False)
-                col_str = raw_input('Enter a new row mask region of trace [1360 1600] (n for none): ') or '1360 1600'
+                try:
+                    col_str = raw_input('Enter a new row mask region of trace [1360 1600] (n for none): ') or '1360 1600'
+                except:
+                    col_str = input('Enter a new row mask region of trace [1360 1600] (n for none): ') or '1360 1600'                    
                 if col_str == 'n':
                     fixed = True
                 else:
                     col_left = int(col_str.split()[0])
                     col_right = int(col_str.split()[1])
                     zapimage[col_left:col_right, trace_x-buff_x:trace_x+buff_x] = 0
-                    new_reg = raw_input('Enter another region [y]/n: ') or 'y'
+                    try:
+                        new_reg = raw_input('Enter another region [y]/n: ') or 'y'
+                    except:
+                        new_reg = input('Enter another region [y]/n: ') or 'y'
                     if new_reg != 'y':
                         fixed = True
                 plt.close()
@@ -569,7 +587,10 @@ def main(*args,**kwargs):
 
     elif os.path.isfile(outfile):
         promptStr = 'Output file {} exists...overwrite? y/[n]: '.format(outfile)
-        usrAns = raw_input(promptStr)
+        try:
+            usrAns = raw_input(promptStr)
+        except:
+            usrAns = input(promptStr)
         if usrAns.strip().upper()[0] == 'Y':
             print('Overwritting...')
             # set clobber to true since we've cleared it with the user


### PR DESCRIPTION
I was noticing that the CR rejection for LRIS red flats is quite poor, which shouldn't be the case for median combine. This is now implemented as a new function in `flat_utils.py` called `combine_flats_sig_clip`

In the process, I found that the `combine_flats` has a major bug. From what I can find, this bug seems to predate you, so I'm not blaming you for this, just to be clear. There's a parameter called `expTime`, defaulted to 0. On line 757-760, the new frame's exposure time is added to expTime, but then expTime is used to scale the data. This way, only the first frame is correctly correctly scaled, but then the n'th frame is divided by n*actual_exposure_time instead of just actual_exposure_time. The correct way to do this would be to have `cumu_expTime` to keep track of the total exposure time (so you can scale things back on line 809) and `current_expTime` for the expTime of the current frame to use to scale the data (line 763). 

Because of this bug, only the frame in the middle of the sequence survive the median combine since everything else gets scaled so far away from median. With this pull request, everything should be using astropy sigma clipped mean to combine the files. I updated `pre_reduction_dev.py` to use this new script by default as well. So far it seems to work quite well. 